### PR TITLE
Implement constants module with tests

### DIFF
--- a/agentlog.txt
+++ b/agentlog.txt
@@ -1,1 +1,2 @@
 2025-06-28: Created repo skeleton per SPECIFICATION T01. Added /public and /src directories with placeholder JS and CSS files. Added CDN links for VexFlow and Font Awesome in public/index.html. Stubbed libs/ and icons/ directories with .gitkeep. No deviations from SPECIFICATION noted.
+2025-06-28: Implemented constants.js per T02 with durations enum, MIDI note name array, and color constants. Added Node test at test/constants.test.mjs verifying exports are frozen and contain expected values.

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,1 +1,17 @@
-// constants
+export const Durations = Object.freeze({
+  WHOLE: 1,
+  HALF: 2,
+  QUARTER: 4,
+  EIGHTH: 8,
+  SIXTEENTH: 16
+});
+
+export const MIDI_NOTE_NAMES = Object.freeze([
+  'C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'
+]);
+
+export const COLORS = Object.freeze({
+  BACKGROUND: '#FFFFFF',
+  STAFF: '#000000',
+  HIGHLIGHT: '#FFD54F'
+});

--- a/test/constants.test.mjs
+++ b/test/constants.test.mjs
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import {Durations, MIDI_NOTE_NAMES, COLORS} from '../src/constants.js';
+
+assert.ok(Object.isFrozen(Durations));
+assert.ok(Object.isFrozen(MIDI_NOTE_NAMES));
+assert.ok(Object.isFrozen(COLORS));
+
+assert.equal(Durations.WHOLE, 1);
+assert.equal(Durations.QUARTER, 4);
+assert.equal(MIDI_NOTE_NAMES[0], 'C');
+assert.equal(MIDI_NOTE_NAMES[11], 'B');
+assert.equal(COLORS.HIGHLIGHT, '#FFD54F');
+
+console.log('constants tests passed');


### PR DESCRIPTION
## Summary
- implement `src/constants.js` with durations, MIDI note names and colours
- add Node-based tests in `test/constants.test.mjs`
- record activity in `agentlog.txt`

## Testing
- `node test/constants.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_685fbd4dfaa0833386b44745987efa0c