### PR TITLE
Implement StateManager and demo

### DIFF
--- a/agentlog.txt
+++ b/agentlog.txt
@@ -2,3 +2,4 @@
 2025-06-28: Implemented constants.js per T02 with durations enum, MIDI note name array, and color constants. Added Node test at test/constants.test.mjs verifying exports are frozen and contain expected values.
 
 2025-06-29: Implemented domain model per T03. Added Note, Rest, Measure, and Score classes with insert/delete logic and beat overflow checks in src/model/score.js. Created test/score.test.mjs covering constructor defaults, insertion with new measure creation, error paths, rest handling, and deletion with measure cleanup. Tests run via Node and pass. No deviations from SPECIFICATION.
+2025-06-30: Implemented StateManager per T04 with event emitter pattern and mutation helpers in src/model/state-manager.js. Added demo script src/demo-state.js that logs changes. Created unit test test/state-manager.test.mjs verifying tool switching, symbol creation, updates, deletion, and event emission. All Node tests pass. No spec deviations.

--- a/src/demo-state.js
+++ b/src/demo-state.js
@@ -1,0 +1,19 @@
+import {StateManager, Tools} from './model/state-manager.js';
+import {Durations} from './constants.js';
+
+const sm = new StateManager();
+sm.onChange(state => {
+  const counts = state.score.measures.map(m => m.symbols.map(s => s.id));
+  console.log('change', {tool: state.currentTool, active: state.activeSymbolId, measures: counts});
+});
+
+sm.setTool(Tools.NOTE);
+sm.beginSymbolCreation({id: 'n1', midi: 60, duration: Durations.QUARTER, index: 0});
+sm.updateActiveSymbol(0, 2);
+sm.commitActiveSymbol();
+
+sm.setTool(Tools.REST);
+sm.beginSymbolCreation({id: 'r1', duration: Durations.QUARTER, index: 1});
+sm.commitActiveSymbol();
+
+sm.deleteSymbol('n1');

--- a/src/model/state-manager.js
+++ b/src/model/state-manager.js
@@ -1,1 +1,98 @@
-// state manager
+import {Score, Note, Rest} from './score.js';
+
+export const Tools = Object.freeze({
+  NOTE: 'note',
+  REST: 'rest',
+  HAND: 'hand',
+  ERASE: 'erase'
+});
+
+export class StateManager {
+  score = new Score({});
+  currentTool = Tools.HAND;
+  activeSymbolId = null;
+  listeners = new Set();
+
+  onChange(cb) {
+    this.listeners.add(cb);
+  }
+
+  emitChange() {
+    for (const cb of this.listeners) {
+      cb(this);
+    }
+  }
+
+  beginSymbolCreation({id, midi, duration, dotted = false, index = 0}) {
+    let symbol;
+    if (this.currentTool === Tools.NOTE) {
+      symbol = new Note({id, midi, duration, dotted});
+    } else if (this.currentTool === Tools.REST) {
+      symbol = new Rest({id, duration, dotted});
+    } else {
+      throw new Error('beginSymbolCreation requires NOTE or REST tool');
+    }
+    this.score.insertSymbol(symbol, index);
+    this.activeSymbolId = id;
+    this.emitChange();
+  }
+
+  findSymbolById(id) {
+    let globalIndex = 0;
+    for (const measure of this.score.measures) {
+      const idx = measure.symbols.findIndex(s => s.id === id);
+      if (idx !== -1) {
+        return {symbol: measure.symbols[idx], index: globalIndex + idx};
+      }
+      globalIndex += measure.symbols.length;
+    }
+    return null;
+  }
+
+  updateActiveSymbol(deltaX = 0, deltaY = 0) {
+    if (!this.activeSymbolId) return;
+    const res = this.findSymbolById(this.activeSymbolId);
+    if (!res) return;
+    const {symbol, index} = res;
+    if (symbol.midi !== undefined && deltaY) {
+      symbol.midi += deltaY;
+    }
+    if (deltaX) {
+      this.score.deleteSymbol(symbol.id);
+      const newIndex = Math.max(0, index + deltaX);
+      this.score.insertSymbol(symbol, newIndex);
+    }
+    this.emitChange();
+  }
+
+  commitActiveSymbol() {
+    if (this.activeSymbolId !== null) {
+      this.activeSymbolId = null;
+      this.emitChange();
+    }
+  }
+
+  moveExistingSymbol(id, deltaX = 0, deltaY = 0) {
+    this.activeSymbolId = id;
+    this.updateActiveSymbol(deltaX, deltaY);
+    this.commitActiveSymbol();
+  }
+
+  deleteSymbol(id) {
+    const removed = this.score.deleteSymbol(id);
+    if (removed) {
+      if (this.activeSymbolId === id) {
+        this.activeSymbolId = null;
+      }
+      this.emitChange();
+    }
+    return removed;
+  }
+
+  setTool(newTool) {
+    if (this.currentTool !== newTool) {
+      this.currentTool = newTool;
+      this.emitChange();
+    }
+  }
+}

--- a/test/state-manager.test.mjs
+++ b/test/state-manager.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import {StateManager, Tools} from '../src/model/state-manager.js';
+import {Durations} from '../src/constants.js';
+
+const sm = new StateManager();
+let events = 0;
+sm.onChange(() => events++);
+
+sm.setTool(Tools.NOTE);
+assert.equal(sm.currentTool, Tools.NOTE);
+
+sm.beginSymbolCreation({id: 'n1', midi: 60, duration: Durations.QUARTER, index: 0});
+assert.equal(sm.activeSymbolId, 'n1');
+assert.equal(sm.score.measures[0].symbols.length, 1);
+
+sm.updateActiveSymbol(0, 2);
+assert.equal(sm.score.measures[0].symbols[0].midi, 62);
+
+sm.commitActiveSymbol();
+assert.equal(sm.activeSymbolId, null);
+
+sm.deleteSymbol('n1');
+assert.equal(sm.score.measures[0].symbols.length, 0);
+
+assert.ok(events >= 5);
+console.log('state-manager tests passed');


### PR DESCRIPTION
## Summary
- add StateManager with event emitter and mutation helpers
- provide demo script to log state changes
- add unit test for StateManager
- log progress in `agentlog.txt`

## Testing
- `node test/constants.test.mjs`
- `node test/score.test.mjs`
- `node test/state-manager.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_685fc04fca908333bf3906a73b5b76d8