### PR TITLE
Implement geometry utils

### DIFF
--- a/agentlog.txt
+++ b/agentlog.txt
@@ -3,3 +3,5 @@
 
 2025-06-29: Implemented domain model per T03. Added Note, Rest, Measure, and Score classes with insert/delete logic and beat overflow checks in src/model/score.js. Created test/score.test.mjs covering constructor defaults, insertion with new measure creation, error paths, rest handling, and deletion with measure cleanup. Tests run via Node and pass. No deviations from SPECIFICATION.
 2025-06-30: Implemented StateManager per T04 with event emitter pattern and mutation helpers in src/model/state-manager.js. Added demo script src/demo-state.js that logs changes. Created unit test test/state-manager.test.mjs verifying tool switching, symbol creation, updates, deletion, and event emission. All Node tests pass. No spec deviations.
+
+2025-06-30: Implemented geometry utilities per T05. Added pointToPitch, pointToInsertIndex, and snapPitch in src/util/geometry.js with basic pixel mapping and diatonic snapping. Created test/geometry.test.mjs covering these functions. All node tests pass. No spec deviations.

--- a/src/util/geometry.js
+++ b/src/util/geometry.js
@@ -1,1 +1,33 @@
 // geometry utilities
+import {MIDI_NOTE_NAMES} from '../constants.js';
+
+const PITCH_BASE = 84; // MIDI note for top reference (C6)
+const PITCH_STEP_PX = 10; // pixels per semitone
+const TIME_STEP_PX = 40; // pixels per score index step
+
+export function pointToPitch(y) {
+  return PITCH_BASE - Math.round(y / PITCH_STEP_PX);
+}
+
+export function pointToInsertIndex(x) {
+  return Math.max(0, Math.floor(x / TIME_STEP_PX));
+}
+
+export function snapPitch(pitch, key = 'C') {
+  const root = MIDI_NOTE_NAMES.indexOf(key);
+  if (root === -1) return pitch;
+  const scale = [0, 2, 4, 5, 7, 9, 11].map(n => (n + root) % 12);
+  let best = pitch;
+  let bestDiff = Infinity;
+  for (const pc of scale) {
+    const base = pitch - (pitch % 12) + pc;
+    for (const candidate of [base - 12, base, base + 12]) {
+      const diff = Math.abs(candidate - pitch);
+      if (diff < bestDiff || (diff === bestDiff && candidate > best)) {
+        bestDiff = diff;
+        best = candidate;
+      }
+    }
+  }
+  return best;
+}

--- a/test/geometry.test.mjs
+++ b/test/geometry.test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import {pointToPitch, pointToInsertIndex, snapPitch} from '../src/util/geometry.js';
+
+// pointToPitch
+assert.equal(pointToPitch(0), 84);
+assert.equal(pointToPitch(10), 83);
+assert.equal(pointToPitch(15), 82);
+
+// pointToInsertIndex
+assert.equal(pointToInsertIndex(0), 0);
+assert.equal(pointToInsertIndex(39), 0);
+assert.equal(pointToInsertIndex(40), 1);
+assert.equal(pointToInsertIndex(81), 2);
+
+// snapPitch
+assert.equal(snapPitch(61, 'C'), 62); // C# -> D in C major
+assert.equal(snapPitch(60, 'G'), 60); // already in scale
+assert.equal(snapPitch(66, 'F'), 67); // F# -> G in F major
+
+console.log('geometry tests passed');


### PR DESCRIPTION
## Summary
- add geometry utilities for pitch and index calculations
- add unit tests for geometry utilities
- log the completed T05 implementation

## Testing
- `node test/constants.test.mjs`
- `node test/score.test.mjs`
- `node test/state-manager.test.mjs`
- `node test/geometry.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_685fc15dccd08333bf1a6a6578b18e2b