### PR TITLE
Fix VexFlow crash with empty measures

### DIFF
--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -58,9 +58,11 @@ export class Renderer {
         }
       });
 
-      voice.addTickables(notes);
-      new VF.Formatter().joinVoices([voice]).format([voice], width - 20);
-      voice.draw(context, stave);
+      if (notes.length > 0) {
+        voice.addTickables(notes);
+        new VF.Formatter().joinVoices([voice]).format([voice], width - 20);
+        voice.draw(context, stave);
+      }
 
       x += width;
     }


### PR DESCRIPTION
## Summary
- avoid calling `Formatter.format` when a measure has no notes

## Testing
- `node test/constants.test.mjs`
- `node test/geometry.test.mjs`
- `node test/score.test.mjs`
- `node test/state-manager.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_685fcd8ed8248333838ea4bc1f9423bd